### PR TITLE
Upgrade elastic search 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/redbadger/rugged.git
-  revision: 6a1085acc4716c31f3fb354d88fab7157f65d3ba
+  revision: c405e9f6b7d23300e0ae6b2175930920c743fa6d
   branch: backends
   submodules: true
   specs:
@@ -10,12 +10,12 @@ PATH
   remote: .
   specs:
     colonel (0.6.1)
-      elasticsearch (~> 1.0.0)
+      elasticsearch (~> 1.0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.0)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -23,34 +23,36 @@ GEM
       tzinfo (~> 1.1)
     builder (3.2.2)
     coderay (1.1.0)
-    cucumber (1.3.18)
+    cucumber (2.1.0)
       builder (>= 2.1.2)
+      cucumber-core (~> 1.3.0)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      gherkin3 (~> 3.1.0)
       multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.1.1)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.3.0)
+      gherkin3 (~> 3.1.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    elasticsearch (1.0.6)
-      elasticsearch-api (= 1.0.6)
-      elasticsearch-transport (= 1.0.6)
-    elasticsearch-api (1.0.6)
+    elasticsearch (1.0.15)
+      elasticsearch-api (= 1.0.15)
+      elasticsearch-transport (= 1.0.15)
+    elasticsearch-api (1.0.15)
       multi_json
-    elasticsearch-transport (1.0.6)
+    elasticsearch-transport (1.0.15)
       faraday
       multi_json
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
+    gherkin3 (3.1.2)
     i18n (0.7.0)
-    json (1.8.1)
+    json (1.8.3)
     method_source (0.8.2)
-    minitest (5.5.0)
-    multi_json (1.10.1)
-    multi_test (0.1.1)
+    minitest (5.8.3)
+    multi_json (1.11.2)
+    multi_test (0.1.2)
     multipart-post (2.0.0)
-    pry (0.10.1)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -69,16 +71,16 @@ GEM
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    shoulda-matchers (2.7.0)
-      activesupport (>= 3.0.0)
-    simplecov (0.9.1)
+    shoulda-matchers (3.0.1)
+      activesupport (>= 4.0.0)
+    simplecov (0.11.1)
       docile (~> 1.1.0)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     thor (0.19.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -97,3 +99,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   thor
+
+BUNDLED WITH
+   1.10.6

--- a/colonel.gemspec
+++ b/colonel.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "elasticsearch", "~> 1.0.0"
+  spec.add_runtime_dependency "elasticsearch", "~> 1.0.6"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "thor"

--- a/lib/colonel/search/elasticsearch_provider.rb
+++ b/lib/colonel/search/elasticsearch_provider.rb
@@ -183,8 +183,8 @@ module Colonel
           revision_type_name=> revision_mapping
         }
 
-        es_client.indices.put_mapping index: index_name, type: type_name, body: item_body
         es_client.indices.put_mapping index: index_name, type: revision_type_name, body: revision_body
+        es_client.indices.put_mapping index: index_name, type: type_name, body: item_body
 
         scopes.each do |name, preds|
           name = "#{type_name}_#{name}"

--- a/provisioning/roles/elasticsearch/defaults/main.yml
+++ b/provisioning/roles/elasticsearch/defaults/main.yml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 elasticsearch:
-  version: 1.0.0
+  version: 2.1.0
   environment:
     - variable: ES_MIN_MEM
       value: 750m

--- a/provisioning/roles/elasticsearch/defaults/main.yml
+++ b/provisioning/roles/elasticsearch/defaults/main.yml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 elasticsearch:
-  version: 2.1.0
+  version: 2.1
   environment:
     - variable: ES_MIN_MEM
       value: 750m

--- a/provisioning/roles/elasticsearch/defaults/main.yml
+++ b/provisioning/roles/elasticsearch/defaults/main.yml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 elasticsearch:
-  version: 2.1
+  version: 2.1.0
   environment:
     - variable: ES_MIN_MEM
       value: 750m


### PR DESCRIPTION
Update elastic search to 2.1

This patch changes the order of mapping creation so that Colonel can work on both Elasticsearch 1.X and 2.X.  It also updates the version of elasticsearch which the tests run against, and the version of the elasticsearch ruby client to the latest.
