### PR TITLE
Add aggs in elasticsearch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    colonel (0.6.1)
+    colonel (0.7.1)
       elasticsearch (~> 1.0.6)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ And then execute:
 
 ### Dependencies
 
+Up to gem version 0.7.x the Colonel can work with elasticsearch 2.x version.
+
 The Colonel requires at least [elasticsearch](http://www.elasticsearch.org) 1.0 to work.
 
 NOTE: The Colonel currently doesn't work with elasticsearch 1.2 or later, which is a known issue

--- a/lib/colonel/search/elasticsearch_result_set.rb
+++ b/lib/colonel/search/elasticsearch_result_set.rb
@@ -9,7 +9,7 @@ module Colonel
   class ElasticsearchResultSet
     include Enumerable
 
-    attr_reader :total, :facets
+    attr_reader :total, :facets, :aggs
 
     # Internal: Create a new result set
     def initialize(results, document_type)
@@ -20,6 +20,7 @@ module Colonel
       @hits   = results["hits"]["hits"]
 
       @facets = results["facets"]
+      @aggs = results["aggregations"]
     end
 
     # Public: Iterate over raw results

--- a/lib/colonel/search/elasticsearch_result_set.rb
+++ b/lib/colonel/search/elasticsearch_result_set.rb
@@ -9,7 +9,7 @@ module Colonel
   class ElasticsearchResultSet
     include Enumerable
 
-    attr_reader :total, :facets, :aggs
+    attr_reader :total, :aggs
 
     # Internal: Create a new result set
     def initialize(results, document_type)
@@ -19,7 +19,6 @@ module Colonel
       @max_score = results["hits"]["max_score"]
       @hits   = results["hits"]["hits"]
 
-      @facets = results["facets"]
       @aggs = results["aggregations"]
     end
 

--- a/lib/colonel/search/elasticsearch_result_set.rb
+++ b/lib/colonel/search/elasticsearch_result_set.rb
@@ -9,7 +9,7 @@ module Colonel
   class ElasticsearchResultSet
     include Enumerable
 
-    attr_reader :total, :aggs
+    attr_reader :total, :facets, :aggs
 
     # Internal: Create a new result set
     def initialize(results, document_type)
@@ -19,6 +19,7 @@ module Colonel
       @max_score = results["hits"]["max_score"]
       @hits   = results["hits"]["hits"]
 
+      @facets = results["facets"]
       @aggs = results["aggregations"]
     end
 

--- a/lib/colonel/version.rb
+++ b/lib/colonel/version.rb
@@ -1,3 +1,3 @@
 module Colonel
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
for elastic search 2.x facets are deprecated. Aggregations are replacement for them. Added aggs to elasticsearch search result set and removed facets which is not in use anymore.
