### PR TITLE
Request timeout

### DIFF
--- a/colonel.gemspec
+++ b/colonel.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "elasticsearch", "~> 1.0.6"
+  spec.add_runtime_dependency "elasticsearch", "~> 1.0.15"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "thor"

--- a/lib/colonel.rb
+++ b/lib/colonel.rb
@@ -21,13 +21,25 @@ require 'colonel/indexer'
 module Colonel
   # Public: Sets configuration options.
   #
-  # Colonel.config.storage_path       - location to store git repo on disk
-  # Colonel.config.index_name         - the name of elasticsearch index to store into
-  # Colonel.config.elasticsearch_uri  - host for elasticsearch
-  # Colonel.config.rugged_backend     - storage backend, an instance of Rugged::Backend
+  # Colonel.config.storage_path               - location to store git repo on disk
+  # Colonel.config.index_name                 - the name of elasticsearch index to store into
+  # Colonel.config.elasticsearch_uri          - host for elasticsearch
+  # Colonel.config.rugged_backend             - storage backend, an instance of Rugged::Backend
+  # Colonel.config.elasticsearch_timeout_secs - request timeout for elasticsearch
   #
   # Returns a config struct
   def self.config
-    @config ||= Struct.new(:storage_path, :index_name, :elasticsearch_uri, :rugged_backend).new('storage', 'colonel-storage', 'localhost:9200', nil)
+    defaults = {
+      :storage_path => 'storage',
+      :index_name => 'colonel-storage',
+      :elasticsearch_uri => 'localhost:9200',
+      :rugged_backend => nil,
+      :elasticsearch_timeout_secs => 60
+    }
+
+    ordered_struct_fields = defaults.keys
+    ordered_struct_values = ordered_struct_fields.map{|k| defaults[k]}
+
+    @config ||= Struct.new(*ordered_struct_fields).new(*ordered_struct_values)
   end
 end

--- a/lib/colonel/search/elasticsearch_provider.rb
+++ b/lib/colonel/search/elasticsearch_provider.rb
@@ -155,9 +155,19 @@ module Colonel
 
       # Public: The Elasticsearch client
       def es_client
-        @es_client ||= ::Elasticsearch::Client.new(host:            Colonel.config.elasticsearch_uri,
-                                                   log:             false,
-                                                   request_timeout: Colonel.config.elasticsearch_timeout_secs)
+        client_opts = {
+          host:            Colonel.config.elasticsearch_uri,
+          log:             false
+        }
+
+        if timeout = Colonel.config.elasticsearch_timeout_secs
+          if timeout <= 0
+            fail "Invalid Colonel.config.elasticsearch_timeout_secs: #{timeout} must be > 0"
+          end
+          client_opts[:request_timeout] = timeout
+        end
+
+        @es_client ||= ::Elasticsearch::Client.new(client_opts)
       end
 
       # Internal: idempotently create the ES index

--- a/lib/colonel/search/elasticsearch_provider.rb
+++ b/lib/colonel/search/elasticsearch_provider.rb
@@ -155,7 +155,9 @@ module Colonel
 
       # Public: The Elasticsearch client
       def es_client
-        @es_client ||= ::Elasticsearch::Client.new(host: Colonel.config.elasticsearch_uri, log: false)
+        @es_client ||= ::Elasticsearch::Client.new(host:            Colonel.config.elasticsearch_uri,
+                                                   log:             false,
+                                                   request_timeout: Colonel.config.elasticsearch_timeout_secs)
       end
 
       # Internal: idempotently create the ES index


### PR DESCRIPTION
This patch allows the user to specify a request timeout for elasticsearch requests.

The `:request_timeout` value is (in this case) passed through to the Faraday Net::HTTP adapter, which uses it to set the `read_timeout` and `open_timeout` values.  This means that the timeout is _per HTTP request_, not cumulative across Colonel API calls.
