### PR TITLE
Fix revision compare

### DIFF
--- a/lib/colonel/document/revision.rb
+++ b/lib/colonel/document/revision.rb
@@ -120,6 +120,7 @@ module Colonel
 
     # Public: Revision equality check by id.
     def ==(other)
+      return false unless other
       id == (other && other.id)
     end
 

--- a/lib/colonel/document/revision.rb
+++ b/lib/colonel/document/revision.rb
@@ -120,8 +120,7 @@ module Colonel
 
     # Public: Revision equality check by id.
     def ==(other)
-      return false unless other
-      id == (other && other.id)
+      other && id == other.id
     end
 
     # Public: Checks whether a revision is the internal root revision which provides

--- a/lib/colonel/version.rb
+++ b/lib/colonel/version.rb
@@ -1,3 +1,3 @@
 module Colonel
-  VERSION = "0.8.1"
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
Previously in revision model method `def ==(other)` returned true if we compare rev == nil. These code changes fixed revision compare method.
