### PR TITLE
Update Ruby to 2.2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in colonel.gemspec
 gemspec
-ruby '2.2.8'
+ruby '2.3.5'
 
 gem 'rugged', git: 'https://github.com/redbadger/rugged.git', branch: 'backends', submodules: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in colonel.gemspec
 gemspec
-ruby '2.1.3'
+ruby '2.2.8'
 
-gem 'rugged', git: 'git://github.com/redbadger/rugged.git', branch: 'backends', submodules: true
+gem 'rugged', git: 'https://github.com/redbadger/rugged.git', branch: 'backends', submodules: true
 
 gem 'cucumber'
 gem 'simplecov', :require => false, :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    colonel (0.8.3)
+    colonel (0.8.4)
       elasticsearch (~> 1.0.6)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     elasticsearch-transport (1.0.18)
       faraday
       multi_json
-    faraday (0.9.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     gherkin3 (3.1.2)
     i18n (0.7.0)
@@ -101,7 +101,7 @@ DEPENDENCIES
   thor
 
 RUBY VERSION
-   ruby 2.2.8p477
+   ruby 2.3.5p376
 
 BUNDLED WITH
    1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/redbadger/rugged.git
+  remote: https://github.com/redbadger/rugged.git
   revision: c405e9f6b7d23300e0ae6b2175930920c743fa6d
   branch: backends
   submodules: true
@@ -99,3 +99,9 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   thor
+
+RUBY VERSION
+   ruby 2.2.8p477
+
+BUNDLED WITH
+   1.15.4

--- a/lib/colonel/document.rb
+++ b/lib/colonel/document.rb
@@ -1,4 +1,5 @@
 module Colonel
+  require 'securerandom'
   # Public: A versioned structured document storage with publishing pipeline support. Documents are internally
   # stored as a single file in a separate git repository for each document. Each state in the publishing
   # process is a separate branch. When saved, document serializes the content to JSON and saves it. Loading

--- a/lib/colonel/version.rb
+++ b/lib/colonel/version.rb
@@ -1,3 +1,3 @@
 module Colonel
-  VERSION = '0.8.3'
+  VERSION = '0.8.4'
 end

--- a/provisioning/development.yml
+++ b/provisioning/development.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 - hosts: devmachines
   user: "{{user}}"

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,12 +1,11 @@
-%YAML 1.2
 ---
 - name: Update apt
   apt: update_cache=yes
-  sudo: yes
+  become: yes
 
 - name: Install dependencies
   apt: pkg={{ item }}
-  sudo: yes
+  become: yes
   with_items:
     - build-essential
     - curl

--- a/provisioning/roles/dev/tasks/main.yml
+++ b/provisioning/roles/dev/tasks/main.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 - name: install global dependencies
   shell: bash -lc "gem install {{item.name}} --no-ri --no-rdoc"
@@ -10,5 +9,4 @@
 
 - name: install dependencies
   shell: cd /vagrant; bash -lc "bundle install"
-  sudo: no
   tags: dependencies

--- a/provisioning/roles/elasticsearch/defaults/main.yml
+++ b/provisioning/roles/elasticsearch/defaults/main.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 elasticsearch:
   version: 2.1.0

--- a/provisioning/roles/elasticsearch/handlers/main.yml
+++ b/provisioning/roles/elasticsearch/handlers/main.yml
@@ -1,5 +1,4 @@
-%YAML 1.2
 ---
 - name: restart elasticsearch
   service: name=elasticsearch state=restarted
-  sudo: yes
+  become: yes

--- a/provisioning/roles/elasticsearch/tasks/main.yml
+++ b/provisioning/roles/elasticsearch/tasks/main.yml
@@ -1,6 +1,4 @@
-%YAML 1.2
 ---
-
 - name: check if elasticsearch is installed
   shell: 'dpkg-query -l elasticsearch | grep -e "ii\s*elasticsearch\s*{{elasticsearch.version}}"'
   register: is_elasticsearch_installed
@@ -13,7 +11,7 @@
        state=present
   with_items:
   - openjdk-7-jre-headless
-  sudo: yes
+  become: yes
   tags: elasticsearch
 
 - name: download elasticsearch
@@ -26,19 +24,17 @@
 - name: install elasticsearch
   when: is_elasticsearch_installed|failed
   command: dpkg -i /tmp/elasticsearch-{{elasticsearch.version}}.deb
-  sudo: yes
+  become: yes
   tags: elasticsearch
 
 - name: elasticsearch plugins
-  shell: './bin/plugin -install {{item.location}}
-          chdir=/usr/share/elasticsearch/
-          creates=/usr/share/elasticsearch/plugins/{{item.name}}'
+  shell: 'yes "Y" | ./bin/plugin install {{item.name}}
+          chdir=/usr/share/elasticsearch/'
   with_items:
-  - name: marvel
-    location: elasticsearch/marvel/latest
+  - name: delete-by-query
   notify:
    - restart elasticsearch
-  sudo: yes
+  become: yes
   tags: elasticsearch
 
 - name: elasticsearch service environment variables
@@ -47,10 +43,10 @@
               regexp='^export {{item.variable}}'
               insertafter='^export ES_JAVA_OPTS'
               line='export {{item.variable}}={{item.value}}'"
-  with_items: ${elasticsearch.environment}
+  with_items: "{{elasticsearch.environment}}"
   notify:
    - restart elasticsearch
-  sudo: yes
+  become: yes
   tags: elasticsearch
 
 - name: ensure elasticsearch is running and enabled
@@ -58,5 +54,5 @@
   service: name=elasticsearch
            state=running
            enabled=yes
-  sudo: yes
+  become: yes
   tags: elasticsearch

--- a/provisioning/roles/rbenv/defaults/main.yml
+++ b/provisioning/roles/rbenv/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 ruby:
-  version: 2.2.8
+  version: 2.3.5

--- a/provisioning/roles/rbenv/defaults/main.yml
+++ b/provisioning/roles/rbenv/defaults/main.yml
@@ -1,4 +1,4 @@
 %YAML 1.2
 ---
 ruby:
-  version: 2.1.0
+  version: 2.2.8

--- a/provisioning/roles/rbenv/defaults/main.yml
+++ b/provisioning/roles/rbenv/defaults/main.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 ruby:
   version: 2.2.8

--- a/provisioning/roles/rbenv/tasks/main.yml
+++ b/provisioning/roles/rbenv/tasks/main.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 - name: Install rbenv
   git: repo=git://github.com/sstephenson/rbenv.git

--- a/provisioning/roles/ruby-build/defaults/main.yml
+++ b/provisioning/roles/ruby-build/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 ruby:
-  version: 2.2.8
+  version: 2.3.5

--- a/provisioning/roles/ruby-build/defaults/main.yml
+++ b/provisioning/roles/ruby-build/defaults/main.yml
@@ -1,4 +1,4 @@
 %YAML 1.2
 ---
 ruby:
-  version: 2.1.0
+  version: 2.2.8

--- a/provisioning/roles/ruby-build/defaults/main.yml
+++ b/provisioning/roles/ruby-build/defaults/main.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 ruby:
   version: 2.2.8

--- a/provisioning/roles/ruby-build/tasks/main.yml
+++ b/provisioning/roles/ruby-build/tasks/main.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 - name: Install ruby build
   git: repo=git://github.com/sstephenson/ruby-build.git

--- a/provisioning/vagrant.yml
+++ b/provisioning/vagrant.yml
@@ -1,3 +1,2 @@
-%YAML 1.2
 ---
 - include: development.yml


### PR DESCRIPTION
https://github.com/sky-uk/Digital-Help/issues/1292

This upgrades Ruby and RubyGems out of a security vulnerability. Ruby is now on a patched version - `2.3.5`.

As part of this, I've also updated the provisioning scripts to support Ansible 2.0.

All existing tests are passing in the Vagrant box.

### To review

* Run the Vagrant box:
  * `vagrant up`
  * `vagrant ssh`
  * `cd /vagrant`
* Run test suites:
  * `bundle exec rspec`
  * `bundle exec cucumber`

### To release

* Merge into master
* Create a new tag:
  * `git tag v0.8.4`
  * `git push origin --tags`
